### PR TITLE
1.20.x to 1.21

### DIFF
--- a/data/crafting_plus/recipe/bed/black_bed.json
+++ b/data/crafting_plus/recipe/bed/black_bed.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:beds",
+      "count": 1
+    },
+    {
+      "item": "minecraft:black_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:black_bed"
+  }
+}

--- a/data/crafting_plus/recipe/bed/blue_bed.json
+++ b/data/crafting_plus/recipe/bed/blue_bed.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:beds",
+      "count": 1
+    },
+    {
+      "item": "minecraft:blue_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:blue_bed"
+  }
+}

--- a/data/crafting_plus/recipe/bed/brown_bed.json
+++ b/data/crafting_plus/recipe/bed/brown_bed.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:beds",
+      "count": 1
+    },
+    {
+      "item": "minecraft:brown_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:brown_bed"
+  }
+}

--- a/data/crafting_plus/recipe/bed/cyan_bed.json
+++ b/data/crafting_plus/recipe/bed/cyan_bed.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:beds",
+      "count": 1
+    },
+    {
+      "item": "minecraft:cyan_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:cyan_bed"
+  }
+}

--- a/data/crafting_plus/recipe/bed/gray_bed.json
+++ b/data/crafting_plus/recipe/bed/gray_bed.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:beds",
+      "count": 1
+    },
+    {
+      "item": "minecraft:gray_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:gray_bed"
+  }
+}

--- a/data/crafting_plus/recipe/bed/green_bed.json
+++ b/data/crafting_plus/recipe/bed/green_bed.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:beds",
+      "count": 1
+    },
+    {
+      "item": "minecraft:green_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:green_bed"
+  }
+}

--- a/data/crafting_plus/recipe/bed/light_blue_bed.json
+++ b/data/crafting_plus/recipe/bed/light_blue_bed.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:beds",
+      "count": 1
+    },
+    {
+      "item": "minecraft:light_blue_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:light_blue_bed"
+  }
+}

--- a/data/crafting_plus/recipe/bed/light_gray_bed.json
+++ b/data/crafting_plus/recipe/bed/light_gray_bed.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:beds",
+      "count": 1
+    },
+    {
+      "item": "minecraft:light_gray_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:light_gray_bed"
+  }
+}

--- a/data/crafting_plus/recipe/bed/lime_bed.json
+++ b/data/crafting_plus/recipe/bed/lime_bed.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:beds",
+      "count": 1
+    },
+    {
+      "item": "minecraft:lime_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:lime_bed"
+  }
+}

--- a/data/crafting_plus/recipe/bed/magenta_bed.json
+++ b/data/crafting_plus/recipe/bed/magenta_bed.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:beds",
+      "count": 1
+    },
+    {
+      "item": "minecraft:magenta_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:magenta_bed"
+  }
+}

--- a/data/crafting_plus/recipe/bed/orange_bed.json
+++ b/data/crafting_plus/recipe/bed/orange_bed.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:beds",
+      "count": 1
+    },
+    {
+      "item": "minecraft:orange_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:orange_bed"
+  }
+}

--- a/data/crafting_plus/recipe/bed/pink_bed.json
+++ b/data/crafting_plus/recipe/bed/pink_bed.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:beds",
+      "count": 1
+    },
+    {
+      "item": "minecraft:pink_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:pink_bed"
+  }
+}

--- a/data/crafting_plus/recipe/bed/purple_bed.json
+++ b/data/crafting_plus/recipe/bed/purple_bed.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:beds",
+      "count": 1
+    },
+    {
+      "item": "minecraft:purple_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:purple_bed"
+  }
+}

--- a/data/crafting_plus/recipe/bed/red_bed.json
+++ b/data/crafting_plus/recipe/bed/red_bed.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:beds",
+      "count": 1
+    },
+    {
+      "item": "minecraft:red_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:red_bed"
+  }
+}

--- a/data/crafting_plus/recipe/bed/white_bed.json
+++ b/data/crafting_plus/recipe/bed/white_bed.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:beds",
+      "count": 1
+    },
+    {
+      "item": "minecraft:white_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:white_bed"
+  }
+}

--- a/data/crafting_plus/recipe/bed/yellow_bed.json
+++ b/data/crafting_plus/recipe/bed/yellow_bed.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:beds",
+      "count": 1
+    },
+    {
+      "item": "minecraft:yellow_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:yellow_bed"
+  }
+}

--- a/data/crafting_plus/recipe/better_beacon.json
+++ b/data/crafting_plus/recipe/better_beacon.json
@@ -1,0 +1,78 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "///",
+    "/@/",
+    "###"
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:obsidian"
+      },
+      {
+        "item": "minecraft:crying_obsidian"
+      }
+    ],
+    "/": [
+      {
+        "item": "minecraft:glass"
+      },
+      {
+        "item": "minecraft:white_stained_glass"
+      },
+      {
+        "item": "minecraft:light_gray_stained_glass"
+      },
+      {
+        "item": "minecraft:gray_stained_glass"
+      },
+      {
+        "item": "minecraft:black_stained_glass"
+      },
+      {
+        "item": "minecraft:brown_stained_glass"
+      },
+      {
+        "item": "minecraft:red_stained_glass"
+      },
+      {
+        "item": "minecraft:orange_stained_glass"
+      },
+      {
+        "item": "minecraft:yellow_stained_glass"
+      },
+      {
+        "item": "minecraft:lime_stained_glass"
+      },
+      {
+        "item": "minecraft:green_stained_glass"
+      },
+      {
+        "item": "minecraft:cyan_stained_glass"
+      },
+      {
+        "item": "minecraft:light_blue_stained_glass"
+      },
+      {
+        "item": "minecraft:blue_stained_glass"
+      },
+      {
+        "item": "minecraft:purple_stained_glass"
+      },
+      {
+        "item": "minecraft:magenta_stained_glass"
+      },
+      {
+        "item": "minecraft:pink_stained_glass"
+      }
+    ],
+    "@": {
+      "item": "minecraft:nether_star"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:beacon"
+  }
+}

--- a/data/crafting_plus/recipe/better_brewer.json
+++ b/data/crafting_plus/recipe/better_brewer.json
@@ -1,0 +1,45 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " / ",
+    "###"
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:cobblestone"
+      },
+      {
+        "item": "minecraft:granite"
+      },
+      {
+        "item": "minecraft:andesite"
+      },
+      {
+        "item": "minecraft:diorite"
+      },
+      {
+        "item": "minecraft:tuff"
+      },
+      {
+        "item": "minecraft:cobbled_deepslate"
+      },
+      {
+        "item": "minecraft:end_stone"
+      },
+      {
+        "item": "minecraft:blackstone"
+      },
+      {
+        "item": "minecraft:netherrack"
+      }
+    ],
+    "/": {
+      "item": "minecraft:blaze_rod"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:brewing_stand"
+  }
+}

--- a/data/crafting_plus/recipe/better_dispenser.json
+++ b/data/crafting_plus/recipe/better_dispenser.json
@@ -1,0 +1,49 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "#/#",
+    "#@#"
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:cobblestone"
+      },
+      {
+        "item": "minecraft:granite"
+      },
+      {
+        "item": "minecraft:andesite"
+      },
+      {
+        "item": "minecraft:diorite"
+      },
+      {
+        "item": "minecraft:tuff"
+      },
+      {
+        "item": "minecraft:cobbled_deepslate"
+      },
+      {
+        "item": "minecraft:end_stone"
+      },
+      {
+        "item": "minecraft:blackstone"
+      },
+      {
+        "item": "minecraft:netherrack"
+      }
+    ],
+    "@": {
+      "item": "minecraft:redstone"
+    },
+    "/": {
+      "item": "minecraft:bow"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:dispenser"
+  }
+}

--- a/data/crafting_plus/recipe/better_dropper.json
+++ b/data/crafting_plus/recipe/better_dropper.json
@@ -1,0 +1,46 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "# #",
+    "#@#"
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:cobblestone"
+      },
+      {
+        "item": "minecraft:granite"
+      },
+      {
+        "item": "minecraft:andesite"
+      },
+      {
+        "item": "minecraft:diorite"
+      },
+      {
+        "item": "minecraft:tuff"
+      },
+      {
+        "item": "minecraft:cobbled_deepslate"
+      },
+      {
+        "item": "minecraft:end_stone"
+      },
+      {
+        "item": "minecraft:blackstone"
+      },
+      {
+        "item": "minecraft:netherrack"
+      }
+    ],
+    "@": {
+      "item": "minecraft:redstone"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:dropper"
+  }
+}

--- a/data/crafting_plus/recipe/better_enchant_table.json
+++ b/data/crafting_plus/recipe/better_enchant_table.json
@@ -1,0 +1,28 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " @ ",
+    "/#/",
+    "###"
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:obsidian"
+      },
+      {
+        "item": "minecraft:crying_obsidian"
+      }
+    ],
+    "/": {
+      "item": "minecraft:diamond"
+    },
+    "@": {
+      "item": "minecraft:book"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:enchanting_table"
+  }
+}

--- a/data/crafting_plus/recipe/better_furnace.json
+++ b/data/crafting_plus/recipe/better_furnace.json
@@ -1,0 +1,43 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "# #",
+    "###"
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:cobblestone"
+      },
+      {
+        "item": "minecraft:granite"
+      },
+      {
+        "item": "minecraft:andesite"
+      },
+      {
+        "item": "minecraft:diorite"
+      },
+      {
+        "item": "minecraft:tuff"
+      },
+      {
+        "item": "minecraft:cobbled_deepslate"
+      },
+      {
+        "item": "minecraft:end_stone"
+      },
+      {
+        "item": "minecraft:blackstone"
+      },
+      {
+        "item": "minecraft:netherrack"
+      }
+    ]
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:furnace"
+  }
+}

--- a/data/crafting_plus/recipe/better_lever.json
+++ b/data/crafting_plus/recipe/better_lever.json
@@ -1,0 +1,45 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/",
+    "#"
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:cobblestone"
+      },
+      {
+        "item": "minecraft:granite"
+      },
+      {
+        "item": "minecraft:andesite"
+      },
+      {
+        "item": "minecraft:diorite"
+      },
+      {
+        "item": "minecraft:tuff"
+      },
+      {
+        "item": "minecraft:cobbled_deepslate"
+      },
+      {
+        "item": "minecraft:end_stone"
+      },
+      {
+        "item": "minecraft:blackstone"
+      },
+      {
+        "item": "minecraft:netherrack"
+      }
+    ],
+    "/": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:lever"
+  }
+}

--- a/data/crafting_plus/recipe/better_observer.json
+++ b/data/crafting_plus/recipe/better_observer.json
@@ -1,0 +1,49 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "@@/",
+    "###"
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:cobblestone"
+      },
+      {
+        "item": "minecraft:granite"
+      },
+      {
+        "item": "minecraft:andesite"
+      },
+      {
+        "item": "minecraft:diorite"
+      },
+      {
+        "item": "minecraft:tuff"
+      },
+      {
+        "item": "minecraft:cobbled_deepslate"
+      },
+      {
+        "item": "minecraft:end_stone"
+      },
+      {
+        "item": "minecraft:blackstone"
+      },
+      {
+        "item": "minecraft:netherrack"
+      }
+    ],
+    "@": {
+      "item": "minecraft:redstone"
+    },
+    "/": {
+      "item": "minecraft:quartz"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:observer"
+  }
+}

--- a/data/crafting_plus/recipe/better_piston.json
+++ b/data/crafting_plus/recipe/better_piston.json
@@ -1,0 +1,81 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "AAA",
+    "#-#",
+    "#@#"
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:cobblestone"
+      },
+      {
+        "item": "minecraft:granite"
+      },
+      {
+        "item": "minecraft:andesite"
+      },
+      {
+        "item": "minecraft:diorite"
+      },
+      {
+        "item": "minecraft:tuff"
+      },
+      {
+        "item": "minecraft:cobbled_deepslate"
+      },
+      {
+        "item": "minecraft:end_stone"
+      },
+      {
+        "item": "minecraft:blackstone"
+      },
+      {
+        "item": "minecraft:netherrack"
+      }
+    ],
+    "@": {
+      "item": "minecraft:redstone"
+    },
+    "A": [
+      {
+        "item": "minecraft:oak_planks"
+      },
+      {
+        "item": "minecraft:birch_planks"
+      },
+      {
+        "item": "minecraft:acacia_planks"
+      },
+      {
+        "item": "minecraft:bamboo_planks"
+      },
+      {
+        "item": "minecraft:cherry_planks"
+      },
+      {
+        "item": "minecraft:jungle_planks"
+      },
+      {
+        "item": "minecraft:spruce_planks"
+      },
+      {
+        "item": "minecraft:warped_planks"
+      },
+      {
+        "item": "minecraft:crimson_planks"
+      },
+      {
+        "item": "minecraft:dark_oak_planks"
+      },
+      {
+        "item": "minecraft:mangrove_planks"
+      }
+    ]
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:dispenser"
+  }
+}

--- a/data/crafting_plus/recipe/better_stone_axe.json
+++ b/data/crafting_plus/recipe/better_stone_axe.json
@@ -1,0 +1,46 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "## ",
+    "#/ ",
+    " / "
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:cobblestone"
+      },
+      {
+        "item": "minecraft:granite"
+      },
+      {
+        "item": "minecraft:andesite"
+      },
+      {
+        "item": "minecraft:diorite"
+      },
+      {
+        "item": "minecraft:tuff"
+      },
+      {
+        "item": "minecraft:cobbled_deepslate"
+      },
+      {
+        "item": "minecraft:end_stone"
+      },
+      {
+        "item": "minecraft:blackstone"
+      },
+      {
+        "item": "minecraft:netherrack"
+      }
+    ],
+    "/": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:stone_axe"
+  }
+}

--- a/data/crafting_plus/recipe/better_stone_axe_alt.json
+++ b/data/crafting_plus/recipe/better_stone_axe_alt.json
@@ -1,0 +1,46 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " ##",
+    " /#",
+    " / "
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:cobblestone"
+      },
+      {
+        "item": "minecraft:granite"
+      },
+      {
+        "item": "minecraft:andesite"
+      },
+      {
+        "item": "minecraft:diorite"
+      },
+      {
+        "item": "minecraft:tuff"
+      },
+      {
+        "item": "minecraft:cobbled_deepslate"
+      },
+      {
+        "item": "minecraft:end_stone"
+      },
+      {
+        "item": "minecraft:blackstone"
+      },
+      {
+        "item": "minecraft:netherrack"
+      }
+    ],
+    "/": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:stone_axe"
+  }
+}

--- a/data/crafting_plus/recipe/better_stone_hoe.json
+++ b/data/crafting_plus/recipe/better_stone_hoe.json
@@ -1,0 +1,46 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " ##",
+    " / ",
+    " / "
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:cobblestone"
+      },
+      {
+        "item": "minecraft:granite"
+      },
+      {
+        "item": "minecraft:andesite"
+      },
+      {
+        "item": "minecraft:diorite"
+      },
+      {
+        "item": "minecraft:tuff"
+      },
+      {
+        "item": "minecraft:cobbled_deepslate"
+      },
+      {
+        "item": "minecraft:end_stone"
+      },
+      {
+        "item": "minecraft:blackstone"
+      },
+      {
+        "item": "minecraft:netherrack"
+      }
+    ],
+    "/": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:stone_hoe"
+  }
+}

--- a/data/crafting_plus/recipe/better_stone_hoe_alt.json
+++ b/data/crafting_plus/recipe/better_stone_hoe_alt.json
@@ -1,0 +1,46 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "## ",
+    " / ",
+    " / "
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:cobblestone"
+      },
+      {
+        "item": "minecraft:granite"
+      },
+      {
+        "item": "minecraft:andesite"
+      },
+      {
+        "item": "minecraft:diorite"
+      },
+      {
+        "item": "minecraft:tuff"
+      },
+      {
+        "item": "minecraft:cobbled_deepslate"
+      },
+      {
+        "item": "minecraft:end_stone"
+      },
+      {
+        "item": "minecraft:blackstone"
+      },
+      {
+        "item": "minecraft:netherrack"
+      }
+    ],
+    "/": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:stone_hoe"
+  }
+}

--- a/data/crafting_plus/recipe/better_stone_pickaxe.json
+++ b/data/crafting_plus/recipe/better_stone_pickaxe.json
@@ -1,0 +1,46 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    " / ",
+    " / "
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:cobblestone"
+      },
+      {
+        "item": "minecraft:granite"
+      },
+      {
+        "item": "minecraft:andesite"
+      },
+      {
+        "item": "minecraft:diorite"
+      },
+      {
+        "item": "minecraft:tuff"
+      },
+      {
+        "item": "minecraft:cobbled_deepslate"
+      },
+      {
+        "item": "minecraft:end_stone"
+      },
+      {
+        "item": "minecraft:blackstone"
+      },
+      {
+        "item": "minecraft:netherrack"
+      }
+    ],
+    "/": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:stone_pickaxe"
+  }
+}

--- a/data/crafting_plus/recipe/better_stone_shovel.json
+++ b/data/crafting_plus/recipe/better_stone_shovel.json
@@ -1,0 +1,46 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " # ",
+    " / ",
+    " / "
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:cobblestone"
+      },
+      {
+        "item": "minecraft:granite"
+      },
+      {
+        "item": "minecraft:andesite"
+      },
+      {
+        "item": "minecraft:diorite"
+      },
+      {
+        "item": "minecraft:tuff"
+      },
+      {
+        "item": "minecraft:cobbled_deepslate"
+      },
+      {
+        "item": "minecraft:end_stone"
+      },
+      {
+        "item": "minecraft:blackstone"
+      },
+      {
+        "item": "minecraft:netherrack"
+      }
+    ],
+    "/": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:stone_shovel"
+  }
+}

--- a/data/crafting_plus/recipe/better_stone_sword.json
+++ b/data/crafting_plus/recipe/better_stone_sword.json
@@ -1,0 +1,46 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " # ",
+    " # ",
+    " / "
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:cobblestone"
+      },
+      {
+        "item": "minecraft:granite"
+      },
+      {
+        "item": "minecraft:andesite"
+      },
+      {
+        "item": "minecraft:diorite"
+      },
+      {
+        "item": "minecraft:tuff"
+      },
+      {
+        "item": "minecraft:cobbled_deepslate"
+      },
+      {
+        "item": "minecraft:end_stone"
+      },
+      {
+        "item": "minecraft:blackstone"
+      },
+      {
+        "item": "minecraft:netherrack"
+      }
+    ],
+    "/": {
+      "item": "minecraft:stick"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:stone_sword"
+  }
+}

--- a/data/crafting_plus/recipe/bulk/bulk_bowl.json
+++ b/data/crafting_plus/recipe/bulk/bulk_bowl.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/ /",
+    " / "
+  ],
+  "key": {
+    "/": {
+      "tag": "minecraft:logs"
+    }
+  },
+  "result": {
+    "count": 16,
+    "id": "minecraft:bowl"
+  }
+}

--- a/data/crafting_plus/recipe/bulk/bulk_bread.json
+++ b/data/crafting_plus/recipe/bulk/bulk_bread.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:hay_block"
+    }
+  },
+  "result": {
+    "count": 9,
+    "id": "minecraft:bread"
+  }
+}

--- a/data/crafting_plus/recipe/bulk/bulk_cauldron.json
+++ b/data/crafting_plus/recipe/bulk/bulk_cauldron.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/ /",
+    "/ /",
+    "///"
+  ],
+  "key": {
+    "/": {
+      "item": "minecraft:iron_block"
+    }
+  },
+  "result": {
+    "count": 9,
+    "id": "minecraft:cauldron"
+  }
+}

--- a/data/crafting_plus/recipe/bulk/bulk_chain.json
+++ b/data/crafting_plus/recipe/bulk/bulk_chain.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/",
+    "#",
+    "/"
+  ],
+  "key": {
+    "/": {
+      "item": "minecraft:iron_ingot"
+    },
+    "#": {
+      "item": "minecraft:iron_block"
+    }
+  },
+  "result": {
+    "count": 9,
+    "id": "minecraft:chain"
+  }
+}

--- a/data/crafting_plus/recipe/bulk/bulk_chests.json
+++ b/data/crafting_plus/recipe/bulk/bulk_chests.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "# #",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "tag": "minecraft:logs"
+    }
+  },
+  "result": {
+    "count": 4,
+    "id": "minecraft:chest"
+  }
+}

--- a/data/crafting_plus/recipe/bulk/bulk_dispenser.json
+++ b/data/crafting_plus/recipe/bulk/bulk_dispenser.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " #/",
+    "#@/",
+    " #/"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "/": {
+      "item": "minecraft:string"
+    },
+    "@": {
+      "item": "minecraft:dropper"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:dispenser"
+  }
+}

--- a/data/crafting_plus/recipe/bulk/bulk_ender_eye.json
+++ b/data/crafting_plus/recipe/bulk/bulk_ender_eye.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:ender_pearl"
+    },
+    {
+      "item": "minecraft:ender_pearl"
+    },
+    {
+      "item": "blaze_rod"
+    }
+  ],
+  "result": {
+    "count": 2,
+    "id": "minecraft:ender_eye"
+  }
+}

--- a/data/crafting_plus/recipe/bulk/bulk_gold_plate.json
+++ b/data/crafting_plus/recipe/bulk/bulk_gold_plate.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "//"
+  ],
+  "key": {
+    "/": {
+      "item": "minecraft:gold_block"
+    }
+  },
+  "result": {
+    "count": 9,
+    "id": "minecraft:light_weighted_pressure_plate"
+  }
+}

--- a/data/crafting_plus/recipe/bulk/bulk_iron_plate.json
+++ b/data/crafting_plus/recipe/bulk/bulk_iron_plate.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "//"
+  ],
+  "key": {
+    "/": {
+      "item": "minecraft:iron_block"
+    }
+  },
+  "result": {
+    "count": 9,
+    "id": "minecraft:heavy_weighted_pressure_plate"
+  }
+}

--- a/data/crafting_plus/recipe/bulk/bulk_ladders.json
+++ b/data/crafting_plus/recipe/bulk/bulk_ladders.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "# #",
+    "###",
+    "# #"
+  ],
+  "key": {
+    "#": {
+      "tag": "minecraft:logs"
+    }
+  },
+  "result": {
+    "count": 24,
+    "id": "minecraft:ladder"
+  }
+}

--- a/data/crafting_plus/recipe/bulk/bulk_snow.json
+++ b/data/crafting_plus/recipe/bulk/bulk_snow.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "///",
+    "///"
+  ],
+  "key": {
+    "/": {
+      "item": "minecraft:snow"
+    }
+  },
+  "result": {
+    "count": 3,
+    "id": "minecraft:snow_block"
+  }
+}

--- a/data/crafting_plus/recipe/bulk/bulk_stick.json
+++ b/data/crafting_plus/recipe/bulk/bulk_stick.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/",
+    "/"
+  ],
+  "key": {
+    "/": {
+      "tag": "minecraft:logs"
+    }
+  },
+  "result": {
+    "count": 16,
+    "id": "minecraft:stick"
+  }
+}

--- a/data/crafting_plus/recipe/bulk_bowl.json
+++ b/data/crafting_plus/recipe/bulk_bowl.json
@@ -1,0 +1,135 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "# #",
+    " # "
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:oak_log"
+      },
+      {
+        "item": "minecraft:spruce_log"
+      },
+      {
+        "item": "minecraft:birch_log"
+      },
+      {
+        "item": "minecraft:jungle_log"
+      },
+      {
+        "item": "minecraft:acacia_log"
+      },
+      {
+        "item": "minecraft:dark_oak_log"
+      },
+      {
+        "item": "minecraft:mangrove_log"
+      },
+      {
+        "item": "minecraft:cherry_log"
+      },
+      {
+        "item": "minecraft:warped_stem"
+      },
+      {
+        "item": "minecraft:crimson_stem"
+      },
+      {
+        "item": "minecraft:oak_wood"
+      },
+      {
+        "item": "minecraft:spruce_wood"
+      },
+      {
+        "item": "minecraft:birch_wood"
+      },
+      {
+        "item": "minecraft:jungle_wood"
+      },
+      {
+        "item": "minecraft:acacia_wood"
+      },
+      {
+        "item": "minecraft:dark_oak_wood"
+      },
+      {
+        "item": "minecraft:mangrove_wood"
+      },
+      {
+        "item": "minecraft:cherry_wood"
+      },
+      {
+        "item": "minecraft:warped_hyphae"
+      },
+      {
+        "item": "minecraft:crimson_hyphae"
+      },
+      {
+        "item": "minecraft:stripped_oak_log"
+      },
+      {
+        "item": "minecraft:stripped_spruce_log"
+      },
+      {
+        "item": "minecraft:stripped_birch_log"
+      },
+      {
+        "item": "minecraft:stripped_jungle_log"
+      },
+      {
+        "item": "minecraft:stripped_acacia_log"
+      },
+      {
+        "item": "minecraft:stripped_dark_oak_log"
+      },
+      {
+        "item": "minecraft:stripped_mangrove_log"
+      },
+      {
+        "item": "minecraft:stripped_cherry_log"
+      },
+      {
+        "item": "minecraft:stripped_warped_stem"
+      },
+      {
+        "item": "minecraft:stripped_crimson_stem"
+      },
+      {
+        "item": "minecraft:stripped_oak_wood"
+      },
+      {
+        "item": "minecraft:stripped_spruce_wood"
+      },
+      {
+        "item": "minecraft:stripped_birch_wood"
+      },
+      {
+        "item": "minecraft:stripped_jungle_wood"
+      },
+      {
+        "item": "minecraft:stripped_acacia_wood"
+      },
+      {
+        "item": "minecraft:stripped_dark_oak_wood"
+      },
+      {
+        "item": "minecraft:stripped_mangrove_wood"
+      },
+      {
+        "item": "minecraft:stripped_cherry_wood"
+      },
+      {
+        "item": "minecraft:stripped_warped_hyphae"
+      },
+      {
+        "item": "minecraft:stripped_crimson_hyphae"
+      }
+    ]
+  },
+  "result": {
+    "count": 16,
+    "id": "minecraft:bowl"
+  }
+}

--- a/data/crafting_plus/recipe/bulk_cauldron.json
+++ b/data/crafting_plus/recipe/bulk_cauldron.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "# #",
+    "# #",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:iron_block"
+    }
+  },
+  "result": {
+    "count": 9,
+    "id": "minecraft:cauldron"
+  }
+}

--- a/data/crafting_plus/recipe/bulk_chain.json
+++ b/data/crafting_plus/recipe/bulk_chain.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "/",
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:iron_ingot"
+    },
+    "/": {
+      "item": "minecraft:iron_block"
+    }
+  },
+  "result": {
+    "count": 9,
+    "id": "minecraft:chain"
+  }
+}

--- a/data/crafting_plus/recipe/bulk_dispenser.json
+++ b/data/crafting_plus/recipe/bulk_dispenser.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " #/",
+    "#@/",
+    " #/"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stick"
+    },
+    "/": {
+      "item": "minecraft:string"
+    },
+    "@": {
+      "item": "minecraft:dropper"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:dispenser"
+  }
+}

--- a/data/crafting_plus/recipe/bulk_ender_eye.json
+++ b/data/crafting_plus/recipe/bulk_ender_eye.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:ender_pearl"
+    },
+    {
+      "item": "minecraft:ender_pearl"
+    },
+    {
+      "item": "blaze_rod"
+    }
+  ],
+  "result": {
+    "count": 2,
+    "id": "minecraft:ender_eye"
+  }
+}

--- a/data/crafting_plus/recipe/bulk_gold_pressure.json
+++ b/data/crafting_plus/recipe/bulk_gold_pressure.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:gold_block"
+    }
+  },
+  "result": {
+    "count": 9,
+    "id": "minecraft:light_weighted_pressure_plate"
+  }
+}

--- a/data/crafting_plus/recipe/bulk_iron_pressure.json
+++ b/data/crafting_plus/recipe/bulk_iron_pressure.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:iron_block"
+    }
+  },
+  "result": {
+    "count": 9,
+    "id": "minecraft:heavy_weighted_pressure_plate"
+  }
+}

--- a/data/crafting_plus/recipe/bulk_minecart.json
+++ b/data/crafting_plus/recipe/bulk_minecart.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "# #",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:iron_block"
+    }
+  },
+  "result": {
+    "count": 9,
+    "id": "minecraft:minecart"
+  }
+}

--- a/data/crafting_plus/recipe/carpet/black_carpet.json
+++ b/data/crafting_plus/recipe/carpet/black_carpet.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "***",
+    "*_*",
+    "***"
+  ],
+  "key": {
+    "*": {
+      "tag": "minecraft:wool_carpets"
+    },
+    "_": {
+      "item": "minecraft:black_dye"
+    }
+  },
+  "result": {
+    "count": 8,
+    "id": "minecraft:black_carpet"
+  }
+}

--- a/data/crafting_plus/recipe/carpet/blue_carpet.json
+++ b/data/crafting_plus/recipe/carpet/blue_carpet.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "***",
+    "*_*",
+    "***"
+  ],
+  "key": {
+    "*": {
+      "tag": "minecraft:wool_carpets"
+    },
+    "_": {
+      "item": "minecraft:blue_dye"
+    }
+  },
+  "result": {
+    "count": 8,
+    "id": "minecraft:blue_carpet"
+  }
+}

--- a/data/crafting_plus/recipe/carpet/brown_carpet.json
+++ b/data/crafting_plus/recipe/carpet/brown_carpet.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "***",
+    "*_*",
+    "***"
+  ],
+  "key": {
+    "*": {
+      "tag": "minecraft:wool_carpets"
+    },
+    "_": {
+      "item": "minecraft:brown_dye"
+    }
+  },
+  "result": {
+    "count": 8,
+    "id": "minecraft:brown_carpet"
+  }
+}

--- a/data/crafting_plus/recipe/carpet/cyan_carpet.json
+++ b/data/crafting_plus/recipe/carpet/cyan_carpet.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "***",
+    "*_*",
+    "***"
+  ],
+  "key": {
+    "*": {
+      "tag": "minecraft:wool_carpets"
+    },
+    "_": {
+      "item": "minecraft:cyan_dye"
+    }
+  },
+  "result": {
+    "count": 8,
+    "id": "minecraft:cyan_carpet"
+  }
+}

--- a/data/crafting_plus/recipe/carpet/gray_carpet.json
+++ b/data/crafting_plus/recipe/carpet/gray_carpet.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "***",
+    "*_*",
+    "***"
+  ],
+  "key": {
+    "*": {
+      "tag": "minecraft:wool_carpets"
+    },
+    "_": {
+      "item": "minecraft:gray_dye"
+    }
+  },
+  "result": {
+    "count": 8,
+    "id": "minecraft:gray_carpet"
+  }
+}

--- a/data/crafting_plus/recipe/carpet/green_carpet.json
+++ b/data/crafting_plus/recipe/carpet/green_carpet.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "***",
+    "*_*",
+    "***"
+  ],
+  "key": {
+    "*": {
+      "tag": "minecraft:wool_carpets"
+    },
+    "_": {
+      "item": "minecraft:green_dye"
+    }
+  },
+  "result": {
+    "count": 8,
+    "id": "minecraft:green_carpet"
+  }
+}

--- a/data/crafting_plus/recipe/carpet/light_blue_carpet.json
+++ b/data/crafting_plus/recipe/carpet/light_blue_carpet.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "***",
+    "*_*",
+    "***"
+  ],
+  "key": {
+    "*": {
+      "tag": "minecraft:wool_carpets"
+    },
+    "_": {
+      "item": "minecraft:light_blue_dye"
+    }
+  },
+  "result": {
+    "count": 8,
+    "id": "minecraft:light_blue_carpet"
+  }
+}

--- a/data/crafting_plus/recipe/carpet/light_gray_carpet.json
+++ b/data/crafting_plus/recipe/carpet/light_gray_carpet.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "***",
+    "*_*",
+    "***"
+  ],
+  "key": {
+    "*": {
+      "tag": "minecraft:wool_carpets"
+    },
+    "_": {
+      "item": "minecraft:light_gray_dye"
+    }
+  },
+  "result": {
+    "count": 8,
+    "id": "minecraft:light_gray_carpet"
+  }
+}

--- a/data/crafting_plus/recipe/carpet/lime_carpet.json
+++ b/data/crafting_plus/recipe/carpet/lime_carpet.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "***",
+    "*_*",
+    "***"
+  ],
+  "key": {
+    "*": {
+      "tag": "minecraft:wool_carpets"
+    },
+    "_": {
+      "item": "minecraft:lime_dye"
+    }
+  },
+  "result": {
+    "count": 8,
+    "id": "minecraft:lime_carpet"
+  }
+}

--- a/data/crafting_plus/recipe/carpet/magenta_carpet.json
+++ b/data/crafting_plus/recipe/carpet/magenta_carpet.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "***",
+    "*_*",
+    "***"
+  ],
+  "key": {
+    "*": {
+      "tag": "minecraft:wool_carpets"
+    },
+    "_": {
+      "item": "minecraft:magenta_dye"
+    }
+  },
+  "result": {
+    "count": 8,
+    "id": "minecraft:magenta_carpet"
+  }
+}

--- a/data/crafting_plus/recipe/carpet/orange_carpet.json
+++ b/data/crafting_plus/recipe/carpet/orange_carpet.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "***",
+    "*_*",
+    "***"
+  ],
+  "key": {
+    "*": {
+      "tag": "minecraft:wool_carpets"
+    },
+    "_": {
+      "item": "minecraft:orange_dye"
+    }
+  },
+  "result": {
+    "count": 8,
+    "id": "minecraft:orange_carpet"
+  }
+}

--- a/data/crafting_plus/recipe/carpet/pink_carpet.json
+++ b/data/crafting_plus/recipe/carpet/pink_carpet.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "***",
+    "*_*",
+    "***"
+  ],
+  "key": {
+    "*": {
+      "tag": "minecraft:wool_carpets"
+    },
+    "_": {
+      "item": "minecraft:pink_dye"
+    }
+  },
+  "result": {
+    "count": 8,
+    "id": "minecraft:pink_carpet"
+  }
+}

--- a/data/crafting_plus/recipe/carpet/purple_carpet.json
+++ b/data/crafting_plus/recipe/carpet/purple_carpet.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "***",
+    "*_*",
+    "***"
+  ],
+  "key": {
+    "*": {
+      "tag": "minecraft:wool_carpets"
+    },
+    "_": {
+      "item": "minecraft:purple_dye"
+    }
+  },
+  "result": {
+    "count": 8,
+    "id": "minecraft:purple_carpet"
+  }
+}

--- a/data/crafting_plus/recipe/carpet/red_carpet.json
+++ b/data/crafting_plus/recipe/carpet/red_carpet.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "***",
+    "*_*",
+    "***"
+  ],
+  "key": {
+    "*": {
+      "tag": "minecraft:wool_carpets"
+    },
+    "_": {
+      "item": "minecraft:red_dye"
+    }
+  },
+  "result": {
+    "count": 8,
+    "id": "minecraft:red_carpet"
+  }
+}

--- a/data/crafting_plus/recipe/carpet/white_carpet.json
+++ b/data/crafting_plus/recipe/carpet/white_carpet.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "***",
+    "*_*",
+    "***"
+  ],
+  "key": {
+    "*": {
+      "tag": "minecraft:wool_carpets"
+    },
+    "_": {
+      "item": "minecraft:white_dye"
+    }
+  },
+  "result": {
+    "count": 8,
+    "id": "minecraft:white_carpet"
+  }
+}

--- a/data/crafting_plus/recipe/carpet/yellow_carpet.json
+++ b/data/crafting_plus/recipe/carpet/yellow_carpet.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "***",
+    "*_*",
+    "***"
+  ],
+  "key": {
+    "*": {
+      "tag": "minecraft:wool_carpets"
+    },
+    "_": {
+      "item": "minecraft:yellow_dye"
+    }
+  },
+  "result": {
+    "count": 8,
+    "id": "minecraft:yellow_carpet"
+  }
+}

--- a/data/crafting_plus/recipe/convert/glowberry_to_glowstone.json
+++ b/data/crafting_plus/recipe/convert/glowberry_to_glowstone.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:glowstone"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:glowstone_dust"
+  }
+}

--- a/data/crafting_plus/recipe/convert/sticks_from_dead_bush.json
+++ b/data/crafting_plus/recipe/convert/sticks_from_dead_bush.json
@@ -1,0 +1,13 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:dead_bush"
+    }
+  ],
+  "result": {
+    "count": 2,
+    "id": "minecraft:stick"
+  },
+  "group": "sticks"
+}

--- a/data/crafting_plus/recipe/craft_brown_mushroom.json
+++ b/data/crafting_plus/recipe/craft_brown_mushroom.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:brown_mushroom"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:brown_mushroom_block"
+  }
+}

--- a/data/crafting_plus/recipe/craft_crimson_nylium.json
+++ b/data/crafting_plus/recipe/craft_crimson_nylium.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/",
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:netherrack"
+    },
+    "/": {
+      "item": "minecraft:crimson_roots"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:crimson_nylium"
+  }
+}

--- a/data/crafting_plus/recipe/craft_nametag.json
+++ b/data/crafting_plus/recipe/craft_nametag.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:ink_sac"
+    },
+    {
+      "item": "minecraft:paper"
+    },
+    {
+      "item": "minecraft:string"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:glowstone_dust"
+  }
+}

--- a/data/crafting_plus/recipe/craft_netherwart_block.json
+++ b/data/crafting_plus/recipe/craft_netherwart_block.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:crimson_fungus"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:nether_wart_block"
+  }
+}

--- a/data/crafting_plus/recipe/craft_red_mushroom.json
+++ b/data/crafting_plus/recipe/craft_red_mushroom.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:red_mushroom"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:red_mushroom_block"
+  }
+}

--- a/data/crafting_plus/recipe/craft_rooted_dirt.json
+++ b/data/crafting_plus/recipe/craft_rooted_dirt.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "/"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:dirt"
+    },
+    "/": {
+      "item": "minecraft:hanging_roots"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:rooted_dirt"
+  }
+}

--- a/data/crafting_plus/recipe/craft_shroomlight.json
+++ b/data/crafting_plus/recipe/craft_shroomlight.json
@@ -1,0 +1,29 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/",
+    "#"
+  ],
+  "key": {
+    "/": [
+      {
+        "item": "minecraft:red_mushroom_block"
+      },
+      {
+        "item": "minecraft:brown_mushroom_block"
+      },
+      {
+        "item": "minecraft:mushroom_stem"
+      }
+    ],
+    "#": [
+      {
+        "item": "minecraft:glowstone"
+      }
+    ]
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:shroomlight"
+  }
+}

--- a/data/crafting_plus/recipe/craft_snow.json
+++ b/data/crafting_plus/recipe/craft_snow.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:snow"
+    }
+  },
+  "result": {
+    "count": 3,
+    "id": "minecraft:snow_block"
+  }
+}

--- a/data/crafting_plus/recipe/craft_twisting_vines.json
+++ b/data/crafting_plus/recipe/craft_twisting_vines.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:warped_roots"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:twisting_vines"
+  }
+}

--- a/data/crafting_plus/recipe/craft_warped_block.json
+++ b/data/crafting_plus/recipe/craft_warped_block.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:warped_fungus"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:warped_wart_block"
+  }
+}

--- a/data/crafting_plus/recipe/craft_warped_nylium.json
+++ b/data/crafting_plus/recipe/craft_warped_nylium.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/",
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:netherrack"
+    },
+    "/": {
+      "item": "minecraft:warped_roots"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:warped_nylium"
+  }
+}

--- a/data/crafting_plus/recipe/craft_weeping_vines.json
+++ b/data/crafting_plus/recipe/craft_weeping_vines.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:crimson_roots"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:weeping_vines"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/craft_brown_mushroom.json
+++ b/data/crafting_plus/recipe/custom_craft/craft_brown_mushroom.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:brown_mushroom"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:brown_mushroom_block"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/craft_crimson_nylium.json
+++ b/data/crafting_plus/recipe/custom_craft/craft_crimson_nylium.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/",
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:netherrack"
+    },
+    "/": {
+      "item": "minecraft:crimson_roots"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:crimson_nylium"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/craft_grass_block.json
+++ b/data/crafting_plus/recipe/custom_craft/craft_grass_block.json
@@ -1,0 +1,29 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/",
+    "#"
+  ],
+  "key": {
+    "/": [
+      {
+        "item": "minecraft:grass"
+      },
+      {
+        "item": "minecraft:moss_carpet"
+      },
+      {
+        "item": "minecraft:tall_grass"
+      }
+    ],
+    "#": [
+      {
+        "item": "minecraft:dirt"
+      }
+    ]
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:grass_block"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/craft_nametag.json
+++ b/data/crafting_plus/recipe/custom_craft/craft_nametag.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:ink_sac"
+    },
+    {
+      "item": "minecraft:paper"
+    },
+    {
+      "item": "minecraft:string"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:name_tag"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/craft_red_mushroom.json
+++ b/data/crafting_plus/recipe/custom_craft/craft_red_mushroom.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "##",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:red_mushroom"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:red_mushroom_block"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/craft_rooted_dirt.json
+++ b/data/crafting_plus/recipe/custom_craft/craft_rooted_dirt.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "/"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:dirt"
+    },
+    "/": {
+      "item": "minecraft:hanging_roots"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:rooted_dirt"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/craft_sculk.json
+++ b/data/crafting_plus/recipe/custom_craft/craft_sculk.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:sculk_vein"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:sculk"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/craft_sculk_catalyst.json
+++ b/data/crafting_plus/recipe/custom_craft/craft_sculk_catalyst.json
@@ -1,0 +1,31 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "///",
+    "#!#",
+    "@@@"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:sculk"
+    },
+    "@": {
+      "item": "minecraft:bone_block"
+    },
+    "!": [
+      {
+        "item": "minecraft:soul_soil"
+      },
+      {
+        "item": "minecraft:soul_sand"
+      }
+    ],
+    "/": {
+      "item": "minecraft:echo_shard"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:sculk_catalyst"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/craft_sculk_sensor.json
+++ b/data/crafting_plus/recipe/custom_craft/craft_sculk_sensor.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/ /",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:sculk"
+    },
+    "/": {
+      "item": "minecraft:echo_shard"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:sculk_sensor"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/craft_sculk_shrieker.json
+++ b/data/crafting_plus/recipe/custom_craft/craft_sculk_shrieker.json
@@ -1,0 +1,31 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "@ @",
+    "/!/",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:sculk"
+    },
+    "@": {
+      "item": "minecraft:bone"
+    },
+    "!": [
+      {
+        "item": "minecraft:soul_soil"
+      },
+      {
+        "item": "minecraft:soul_sand"
+      }
+    ],
+    "/": {
+      "item": "minecraft:echo_shard"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:sculk_shrieker"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/craft_shroomlight.json
+++ b/data/crafting_plus/recipe/custom_craft/craft_shroomlight.json
@@ -1,0 +1,29 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/",
+    "#"
+  ],
+  "key": {
+    "/": [
+      {
+        "item": "minecraft:red_mushroom_block"
+      },
+      {
+        "item": "minecraft:brown_mushroom_block"
+      },
+      {
+        "item": "minecraft:mushroom_stem"
+      }
+    ],
+    "#": [
+      {
+        "item": "minecraft:glowstone"
+      }
+    ]
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:shroomlight"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/craft_twisting_vines.json
+++ b/data/crafting_plus/recipe/custom_craft/craft_twisting_vines.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:warped_roots"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:twisting_vines"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/craft_warped_block.json
+++ b/data/crafting_plus/recipe/custom_craft/craft_warped_block.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "###",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:warped_fungus"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:warped_wart_block"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/craft_warped_nylium.json
+++ b/data/crafting_plus/recipe/custom_craft/craft_warped_nylium.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "/",
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:netherrack"
+    },
+    "/": {
+      "item": "minecraft:warped_roots"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:warped_nylium"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/craft_web.json
+++ b/data/crafting_plus/recipe/custom_craft/craft_web.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "# #",
+    " # ",
+    "# #"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:string"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:cobweb"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/craft_weeping_vines.json
+++ b/data/crafting_plus/recipe/custom_craft/craft_weeping_vines.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:crimson_roots"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:weeping_vines"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/ench_gold_apple.json
+++ b/data/crafting_plus/recipe/custom_craft/ench_gold_apple.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "#@#",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:gold_block"
+    },
+    "@": {
+      "item": "minecraft:golden_apple"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:enchanted_golden_apple"
+  }
+}

--- a/data/crafting_plus/recipe/custom_craft/uncraft_calibrated_sensor.json
+++ b/data/crafting_plus/recipe/custom_craft/uncraft_calibrated_sensor.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " / ",
+    "/#/"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:calibrated_sculk_sensor"
+    },
+    "/": {
+      "item": "minecraft:echo_shard"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:sculk_sensor"
+  }
+}

--- a/data/crafting_plus/recipe/dyes/black_dye_from_coal.json
+++ b/data/crafting_plus/recipe/dyes/black_dye_from_coal.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:smelting",
+  "ingredient": {
+    "item": "minecraft:coal"
+  },
+  "result": {
+    "id": "minecraft:black_dye"
+  },
+  "experience": 0.1,
+  "cookingtime": 200
+}

--- a/data/crafting_plus/recipe/dyes/brown_dye_from_dyes.json
+++ b/data/crafting_plus/recipe/dyes/brown_dye_from_dyes.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:orange_dye"
+    },
+    {
+      "item": "minecraft:black_dye"
+    }
+  ],
+  "result": {
+    "count": 2,
+    "id": "minecraft:brown_dye"
+  }
+}

--- a/data/crafting_plus/recipe/dyes/green_dye_from_dried_kelp.json
+++ b/data/crafting_plus/recipe/dyes/green_dye_from_dried_kelp.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:dried_kelp"
+    }
+  ],
+  "result": {
+    "id": "minecraft:green_dye"
+  }
+}

--- a/data/crafting_plus/recipe/dyes/green_dye_from_moss_block.json
+++ b/data/crafting_plus/recipe/dyes/green_dye_from_moss_block.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:smelting",
+  "ingredient": {
+    "item": "minecraft:moss_block"
+  },
+  "result": {
+    "id": "minecraft:green_dye"
+  },
+  "experience": 0.1,
+  "cookingtime": 200
+}

--- a/data/crafting_plus/recipe/dyes/magenta_dye_from_flowering_azalea.json
+++ b/data/crafting_plus/recipe/dyes/magenta_dye_from_flowering_azalea.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:flowering_azalea"
+    }
+  ],
+  "result": {
+    "id": "minecraft:magenta_dye"
+  }
+}

--- a/data/crafting_plus/recipe/dyes/magenta_dye_from_flowering_azalea_leaves.json
+++ b/data/crafting_plus/recipe/dyes/magenta_dye_from_flowering_azalea_leaves.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:flowering_azalea_leaves"
+    }
+  ],
+  "result": {
+    "id": "minecraft:magenta_dye"
+  }
+}

--- a/data/crafting_plus/recipe/dyes/magenta_dye_from_popped_chorus_fruit.json
+++ b/data/crafting_plus/recipe/dyes/magenta_dye_from_popped_chorus_fruit.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:popped_chorus_fruit"
+    }
+  ],
+  "result": {
+    "id": "minecraft:magenta_dye"
+  }
+}

--- a/data/crafting_plus/recipe/dyes/pink_dye_from_spore_blossom.json
+++ b/data/crafting_plus/recipe/dyes/pink_dye_from_spore_blossom.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:spore_blossom"
+    }
+  ],
+  "result": {
+    "id": "minecraft:pink_dye"
+  }
+}

--- a/data/crafting_plus/recipe/dyes/purple_dye_from_amethyst_shard.json
+++ b/data/crafting_plus/recipe/dyes/purple_dye_from_amethyst_shard.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:amethyst_shard"
+    }
+  ],
+  "result": {
+    "id": "minecraft:purple_dye"
+  }
+}

--- a/data/crafting_plus/recipe/dyes/red_dye_from_sweet_berries.json
+++ b/data/crafting_plus/recipe/dyes/red_dye_from_sweet_berries.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:smelting",
+  "ingredient": {
+    "item": "minecraft:sweet_berries"
+  },
+  "result": {
+    "id": "minecraft:red_dye"
+  },
+  "experience": 0.1,
+  "cookingtime": 200
+}

--- a/data/crafting_plus/recipe/dyes/writable_book_from_black_dye.json
+++ b/data/crafting_plus/recipe/dyes/writable_book_from_black_dye.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:book"
+    },
+    {
+      "item": "minecraft:black_dye"
+    },
+    {
+      "item": "minecraft:feather"
+    }
+  ],
+  "result": {
+    "id": "minecraft:writable_book"
+  }
+}

--- a/data/crafting_plus/recipe/ench_gold_apple.json
+++ b/data/crafting_plus/recipe/ench_gold_apple.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "#@#",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:gold_block"
+    },
+    "@": {
+      "item": "minecraft:golden_apple"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:enchanted_golden_apple"
+  }
+}

--- a/data/crafting_plus/recipe/glowberry_to_glowstone.json
+++ b/data/crafting_plus/recipe/glowberry_to_glowstone.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:glowstone"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:glowstone_dust"
+  }
+}

--- a/data/crafting_plus/recipe/grass_block.json
+++ b/data/crafting_plus/recipe/grass_block.json
@@ -1,0 +1,29 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "A",
+    "#"
+  ],
+  "key": {
+    "A": [
+      {
+        "item": "minecraft:grass"
+      },
+      {
+        "item": "minecraft:moss_carpet"
+      },
+      {
+        "item": "minecraft:tall_grass"
+      }
+    ],
+    "#": [
+      {
+        "item": "minecraft:dirt"
+      }
+    ]
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:grass_block"
+  }
+}

--- a/data/crafting_plus/recipe/hay_to_bread.json
+++ b/data/crafting_plus/recipe/hay_to_bread.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:hay_block"
+    }
+  },
+  "result": {
+    "count": 9,
+    "id": "minecraft:bread"
+  }
+}

--- a/data/crafting_plus/recipe/log_to_chests.json
+++ b/data/crafting_plus/recipe/log_to_chests.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "###",
+    "# #",
+    "###"
+  ],
+  "key": {
+    "#": [
+      {
+        "tag": "minecraft:logs"
+      }
+    ]
+  },
+  "result": {
+    "count": 4,
+    "id": "minecraft:chest"
+  }
+}

--- a/data/crafting_plus/recipe/log_to_ladder.json
+++ b/data/crafting_plus/recipe/log_to_ladder.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "# #",
+    "###",
+    "# #"
+  ],
+  "key": {
+    "#": [
+      {
+        "tag": "minecraft:logs"
+      }
+    ]
+  },
+  "result": {
+    "count": 24,
+    "id": "minecraft:ladder"
+  }
+}

--- a/data/crafting_plus/recipe/log_to_sticks.json
+++ b/data/crafting_plus/recipe/log_to_sticks.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#",
+    "#"
+  ],
+  "key": {
+    "#": [
+      {
+        "tag": "minecraft:logs"
+      }
+    ]
+  },
+  "result": {
+    "count": 16,
+    "id": "minecraft:stick"
+  }
+}

--- a/data/crafting_plus/recipe/minecarts/chest_minecart_fast.json
+++ b/data/crafting_plus/recipe/minecarts/chest_minecart_fast.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "iCi",
+    "iii"
+  ],
+  "key": {
+    "i": {
+      "item": "minecraft:iron_ingot"
+    },
+    "C": {
+      "item": "minecraft:chest"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:chest_minecart"
+  }
+}

--- a/data/crafting_plus/recipe/minecarts/furnace_minecart_fast.json
+++ b/data/crafting_plus/recipe/minecarts/furnace_minecart_fast.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "iFi",
+    "iii"
+  ],
+  "key": {
+    "i": {
+      "item": "minecraft:iron_ingot"
+    },
+    "F": {
+      "item": "minecraft:furnace"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:furnace_minecart"
+  }
+}

--- a/data/crafting_plus/recipe/minecarts/hopper_minecart_fast.json
+++ b/data/crafting_plus/recipe/minecarts/hopper_minecart_fast.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "iHi",
+    "iii"
+  ],
+  "key": {
+    "i": {
+      "item": "minecraft:iron_ingot"
+    },
+    "H": {
+      "item": "minecraft:hopper"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:hopper_minecart"
+  }
+}

--- a/data/crafting_plus/recipe/minecarts/tnt_minecart_fast.json
+++ b/data/crafting_plus/recipe/minecarts/tnt_minecart_fast.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "iTi",
+    "iii"
+  ],
+  "key": {
+    "i": {
+      "item": "minecraft:iron_ingot"
+    },
+    "T": {
+      "item": "minecraft:tnt"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:tnt_minecart"
+  }
+}

--- a/data/crafting_plus/recipe/mosaic_to_slabs.json
+++ b/data/crafting_plus/recipe/mosaic_to_slabs.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:bamboo_mosaic"
+    }
+  ],
+  "result": {
+    "count": 2,
+    "id": "minecraft:bamboo_slab"
+  }
+}

--- a/data/crafting_plus/recipe/ores/coal_ore.json
+++ b/data/crafting_plus/recipe/ores/coal_ore.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "/#/",
+    "#/#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stone"
+    },
+    "/": {
+      "item": "minecraft:coal"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:coal_ore"
+  }
+}

--- a/data/crafting_plus/recipe/ores/coal_ore_deepslate.json
+++ b/data/crafting_plus/recipe/ores/coal_ore_deepslate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "/#/",
+    "#/#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:deepslate"
+    },
+    "/": {
+      "item": "minecraft:coal"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:deepslate_coal_ore"
+  }
+}

--- a/data/crafting_plus/recipe/ores/copper_ore.json
+++ b/data/crafting_plus/recipe/ores/copper_ore.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "/#/",
+    "#/#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stone"
+    },
+    "/": {
+      "item": "minecraft:raw_copper"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:copper_ore"
+  }
+}

--- a/data/crafting_plus/recipe/ores/copper_ore_deepslate.json
+++ b/data/crafting_plus/recipe/ores/copper_ore_deepslate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "/#/",
+    "#/#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:deepslate"
+    },
+    "/": {
+      "item": "minecraft:raw_copper"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:deepslate_copper_ore"
+  }
+}

--- a/data/crafting_plus/recipe/ores/diamond_ore.json
+++ b/data/crafting_plus/recipe/ores/diamond_ore.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "/#/",
+    "#/#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stone"
+    },
+    "/": {
+      "item": "minecraft:diamond"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:diamond_ore"
+  }
+}

--- a/data/crafting_plus/recipe/ores/diamond_ore_deepslate.json
+++ b/data/crafting_plus/recipe/ores/diamond_ore_deepslate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "/#/",
+    "#/#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:deepslate"
+    },
+    "/": {
+      "item": "minecraft:diamond"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:deepslate_diamond_ore"
+  }
+}

--- a/data/crafting_plus/recipe/ores/emerald_ore.json
+++ b/data/crafting_plus/recipe/ores/emerald_ore.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "/#/",
+    "#/#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stone"
+    },
+    "/": {
+      "item": "minecraft:emerald"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:emerald_ore"
+  }
+}

--- a/data/crafting_plus/recipe/ores/emerald_ore_deepslate.json
+++ b/data/crafting_plus/recipe/ores/emerald_ore_deepslate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "/#/",
+    "#/#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:deepslate"
+    },
+    "/": {
+      "item": "minecraft:emerald"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:deepslate_emerald_ore"
+  }
+}

--- a/data/crafting_plus/recipe/ores/gold_ore.json
+++ b/data/crafting_plus/recipe/ores/gold_ore.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "/#/",
+    "#/#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stone"
+    },
+    "/": {
+      "item": "minecraft:raw_gold"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:gold_ore"
+  }
+}

--- a/data/crafting_plus/recipe/ores/gold_ore_deepslate.json
+++ b/data/crafting_plus/recipe/ores/gold_ore_deepslate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "/#/",
+    "#/#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:deepslate"
+    },
+    "/": {
+      "item": "minecraft:raw_gold"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:deepslate_gold_ore"
+  }
+}

--- a/data/crafting_plus/recipe/ores/iron_ore.json
+++ b/data/crafting_plus/recipe/ores/iron_ore.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "/#/",
+    "#/#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stone"
+    },
+    "/": {
+      "item": "minecraft:raw_iron"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:iron_ore"
+  }
+}

--- a/data/crafting_plus/recipe/ores/iron_ore_deepslate.json
+++ b/data/crafting_plus/recipe/ores/iron_ore_deepslate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "/#/",
+    "#/#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:deepslate"
+    },
+    "/": {
+      "item": "minecraft:raw_iron"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:deepslate_iron_ore"
+  }
+}

--- a/data/crafting_plus/recipe/ores/lapis_ore.json
+++ b/data/crafting_plus/recipe/ores/lapis_ore.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "/#/",
+    "#/#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stone"
+    },
+    "/": {
+      "item": "minecraft:lapis_lazuli"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:lapis_ore"
+  }
+}

--- a/data/crafting_plus/recipe/ores/lapis_ore_deepslate.json
+++ b/data/crafting_plus/recipe/ores/lapis_ore_deepslate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "/#/",
+    "#/#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:deepslate"
+    },
+    "/": {
+      "item": "minecraft:lapis_lazuli"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:deepslate_lapis_ore"
+  }
+}

--- a/data/crafting_plus/recipe/ores/redstone_ore.json
+++ b/data/crafting_plus/recipe/ores/redstone_ore.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "/#/",
+    "#/#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stone"
+    },
+    "/": {
+      "item": "minecraft:redstone"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:redstone_ore"
+  }
+}

--- a/data/crafting_plus/recipe/ores/redstone_ore_deepslate.json
+++ b/data/crafting_plus/recipe/ores/redstone_ore_deepslate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "/#/",
+    "#/#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:deepslate"
+    },
+    "/": {
+      "item": "minecraft:redstone"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:deepslate_redstone_ore"
+  }
+}

--- a/data/crafting_plus/recipe/raw_chest_minecart.json
+++ b/data/crafting_plus/recipe/raw_chest_minecart.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:iron_ingot"
+    },
+    "/": {
+      "item": "minecraft:chest"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:chest_minecart"
+  }
+}

--- a/data/crafting_plus/recipe/raw_copper_to_block.json
+++ b/data/crafting_plus/recipe/raw_copper_to_block.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:smelting",
+  "ingredient": {
+    "item": "minecraft:raw_copper_block"
+  },
+  "result": {
+    "id": "minecraft:copper_block"
+  },
+  "experience": 0.1,
+  "cookingtime": 200
+}

--- a/data/crafting_plus/recipe/raw_copper_to_block_blast.json
+++ b/data/crafting_plus/recipe/raw_copper_to_block_blast.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:blasting",
+  "ingredient": {
+    "item": "minecraft:raw_copper_block"
+  },
+  "result": {
+    "id": "minecraft:copper_block"
+  },
+  "experience": 0.1,
+  "cookingtime": 200
+}

--- a/data/crafting_plus/recipe/raw_furnace_minecart.json
+++ b/data/crafting_plus/recipe/raw_furnace_minecart.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:iron_ingot"
+    },
+    "/": {
+      "item": "minecraft:furnace"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:furnace_minecart"
+  }
+}

--- a/data/crafting_plus/recipe/raw_gold_to_block.json
+++ b/data/crafting_plus/recipe/raw_gold_to_block.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:smelting",
+  "ingredient": {
+    "item": "minecraft:raw_gold_block"
+  },
+  "result": {
+    "id": "minecraft:gold_block"
+  },
+  "experience": 0.1,
+  "cookingtime": 200
+}

--- a/data/crafting_plus/recipe/raw_gold_to_block_blast.json
+++ b/data/crafting_plus/recipe/raw_gold_to_block_blast.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:blasting",
+  "ingredient": {
+    "item": "minecraft:raw_gold_block"
+  },
+  "result": {
+    "id": "minecraft:gold_block"
+  },
+  "experience": 0.1,
+  "cookingtime": 200
+}

--- a/data/crafting_plus/recipe/raw_hopper_minecart.json
+++ b/data/crafting_plus/recipe/raw_hopper_minecart.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:iron_ingot"
+    },
+    "/": {
+      "item": "minecraft:hopper"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:hopper_minecart"
+  }
+}

--- a/data/crafting_plus/recipe/raw_iron_to_block.json
+++ b/data/crafting_plus/recipe/raw_iron_to_block.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:smelting",
+  "ingredient": {
+    "item": "minecraft:raw_iron_block"
+  },
+  "result": {
+    "id": "minecraft:iron_block"
+  },
+  "experience": 0.1,
+  "cookingtime": 200
+}

--- a/data/crafting_plus/recipe/raw_iron_to_block_blast.json
+++ b/data/crafting_plus/recipe/raw_iron_to_block_blast.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:blasting",
+  "ingredient": {
+    "item": "minecraft:raw_iron_block"
+  },
+  "result": {
+    "id": "minecraft:iron_block"
+  },
+  "experience": 0.1,
+  "cookingtime": 200
+}

--- a/data/crafting_plus/recipe/raw_repeater.json
+++ b/data/crafting_plus/recipe/raw_repeater.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "@ @",
+    "/@/",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:stone"
+    },
+    "/": {
+      "item": "minecraft:stick"
+    },
+    "@": {
+      "item": "minecraft:redstone"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:repeater"
+  }
+}

--- a/data/crafting_plus/recipe/raw_tnt_minecart.json
+++ b/data/crafting_plus/recipe/raw_tnt_minecart.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#/#",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:iron_ingot"
+    },
+    "/": {
+      "item": "minecraft:tnt"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:tnt_minecart"
+  }
+}

--- a/data/crafting_plus/recipe/smelt_flesh.json
+++ b/data/crafting_plus/recipe/smelt_flesh.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:smelting",
+  "ingredient": {
+    "item": "minecraft:rotten_flesh"
+  },
+  "result": {
+    "id": "minecraft:leather"
+  },
+  "experience": 0.1,
+  "cookingtime": 200
+}

--- a/data/crafting_plus/recipe/smelt_sapling.json
+++ b/data/crafting_plus/recipe/smelt_sapling.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:smelting",
+  "ingredient": {
+    "tag": "minecraft:saplings"
+  },
+  "result": {
+    "id": "minecraft:dead_bush"
+  },
+  "experience": 0.1,
+  "cookingtime": 200
+}

--- a/data/crafting_plus/recipe/spectral_arrow.json
+++ b/data/crafting_plus/recipe/spectral_arrow.json
@@ -1,0 +1,28 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " # ",
+    "#/#",
+    " # "
+  ],
+  "key": {
+    "#": [
+      {
+        "item": "minecraft:glow_berries"
+      },
+      {
+        "item": "minecraft:glow_ink_sac"
+      },
+      {
+        "item": "glowstone_dust"
+      }
+    ],
+    "/": {
+      "item": "minecraft:arrow"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:spectral_arrow"
+  }
+}

--- a/data/crafting_plus/recipe/string_to_web.json
+++ b/data/crafting_plus/recipe/string_to_web.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "# #",
+    " # ",
+    "# #"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:string"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:cobweb"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_acacia_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_acacia_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:acacia_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:acacia_planks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_amethyst.json
+++ b/data/crafting_plus/recipe/uncraft_amethyst.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:amethyst_block"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:amethyst_shard"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_andesite_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_andesite_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:andesite_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:andesite"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_bamboo_mosaic_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_bamboo_mosaic_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:bamboo_mosaic_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:bamboo_mosaic"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_bamboo_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_bamboo_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:bamboo_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:bamboo_planks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_birch_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_birch_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:birch_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:birch_planks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_blackstone_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_blackstone_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:blackstone_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:blackstone"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_blue_ice.json
+++ b/data/crafting_plus/recipe/uncraft_blue_ice.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:blue_ice"
+    }
+  ],
+  "result": {
+    "count": 9,
+    "id": "minecraft:packed_ice"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_bricks_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_bricks_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:brick_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:bricks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_brown_mushroom.json
+++ b/data/crafting_plus/recipe/uncraft_brown_mushroom.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:brown_mushroom_block"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:brown_mushroom"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_cherry_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_cherry_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:cherry_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:cherry_planks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_clay_block.json
+++ b/data/crafting_plus/recipe/uncraft_clay_block.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:clay"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:clay_ball"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_cobbled_deepslate_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_cobbled_deepslate_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:cobbled_deepslate_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:cobbled_deepslate"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_cobblestone_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_cobblestone_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:cobblestone_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:cobblestone"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_cobweb.json
+++ b/data/crafting_plus/recipe/uncraft_cobweb.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:cobweb"
+    }
+  ],
+  "result": {
+    "count": 5,
+    "id": "minecraft:string"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_crimson_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_crimson_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:crimson_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:crimson_planks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_cut_copper_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_cut_copper_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:cut_copper_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:cut_copper"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_cut_red_sandstone_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_cut_red_sandstone_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:cut_red_sandstone_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:cut_red_sandstone"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_cut_sandstone_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_cut_sandstone_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:cut_sandstone_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:cut_sandstone"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_dark_oak_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_dark_oak_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:dark_oak_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:dark_oak_planks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_dark_prismarine_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_dark_prismarine_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:dark_prismarine_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:dark_prismarine"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_deepslate_bricks_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_deepslate_bricks_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:deepslate_brick_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:deepslate_bricks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_deepslate_tiles_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_deepslate_tiles_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:deepslate_tile_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:deepslate_tiles"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_diorite_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_diorite_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:diorite_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:diorite"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_dripstone.json
+++ b/data/crafting_plus/recipe/uncraft_dripstone.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:dripstone_block"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:pointed_dripstone"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_end_stone_bricks_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_end_stone_bricks_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:end_stone_brick_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:end_stone_bricks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_exposed_cut_copper_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_exposed_cut_copper_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:exposed_cut_copper_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:exposed_cut_copper"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_glowstone.json
+++ b/data/crafting_plus/recipe/uncraft_glowstone.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:glowstone"
+    }
+  },
+  "result": {
+    "count": 4,
+    "id": "minecraft:glowstone_dust"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_granite_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_granite_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:granite_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:granite"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_gravel.json
+++ b/data/crafting_plus/recipe/uncraft_gravel.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "# ",
+    "##"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:gravel"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:flint"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_honey.json
+++ b/data/crafting_plus/recipe/uncraft_honey.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:honey_block"
+    }
+  },
+  "result": {
+    "count": 4,
+    "id": "minecraft:honey_bottle"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_honeycomb_block.json
+++ b/data/crafting_plus/recipe/uncraft_honeycomb_block.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:honeycomb_block"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:honeycomb"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_jungle_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_jungle_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:jungle_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:jungle_planks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_magma.json
+++ b/data/crafting_plus/recipe/uncraft_magma.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:magma_block"
+    }
+  },
+  "result": {
+    "count": 4,
+    "id": "minecraft:magma_cream"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_mangrove_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_mangrove_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:mangrove_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:mangrove_planks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_melon.json
+++ b/data/crafting_plus/recipe/uncraft_melon.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:melon"
+    }
+  },
+  "result": {
+    "count": 9,
+    "id": "minecraft:melon_slice"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_mossy_cobblestone_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_mossy_cobblestone_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:mossy_cobblestone_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:mossy_cobblestone"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_mossy_stone_brick_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_mossy_stone_brick_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:mossy_stone_brick_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:mossy_stone_bricks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_mud_bricks_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_mud_bricks_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:mud_brick_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:mud_bricks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_nether_bricks.json
+++ b/data/crafting_plus/recipe/uncraft_nether_bricks.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:nether_bricks"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:nether_brick"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_nether_bricks_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_nether_bricks_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:nether_brick_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:nether_bricks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_nether_wart_block.json
+++ b/data/crafting_plus/recipe/uncraft_nether_wart_block.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:nether_wart_block"
+    }
+  ],
+  "result": {
+    "count": 9,
+    "id": "minecraft:nether_wart"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_oak_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_oak_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:oak_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:oak_planks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_oxidized_cut_copper_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_oxidized_cut_copper_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:oxidized_cut_copper_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:oxidized_cut_copper"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_packed_ice.json
+++ b/data/crafting_plus/recipe/uncraft_packed_ice.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:packed_ice"
+    }
+  ],
+  "result": {
+    "count": 9,
+    "id": "minecraft:ice"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_polished_andesite_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_polished_andesite_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:polished_andesite_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:polished_andesite"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_polished_blackstone_bricks_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_polished_blackstone_bricks_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:polished_blackstone_brick_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:polished_blackstone_bricks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_polished_blackstone_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_polished_blackstone_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:polished_blackstone_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:polished_blackstone"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_polished_diorite_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_polished_diorite_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:polished_diorite_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:polished_diorite"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_polished_granite_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_polished_granite_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:polished_granite_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:polished_granite"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_prismarine_bricks_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_prismarine_bricks_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:prismarine_brick_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:prismarine_bricks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_prismarine_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_prismarine_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:prismarine_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:prismarine"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_purpur_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_purpur_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:purpur_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:purpur_block"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_quartz_block.json
+++ b/data/crafting_plus/recipe/uncraft_quartz_block.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:quartz_block"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:quartz"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_quartz_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_quartz_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:quartz_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:quartz_block"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_red_mushroom.json
+++ b/data/crafting_plus/recipe/uncraft_red_mushroom.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:red_mushroom_block"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:red_mushroom"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_red_nether_bricks.json
+++ b/data/crafting_plus/recipe/uncraft_red_nether_bricks.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:red_nether_bricks"
+    }
+  ],
+  "result": {
+    "count": 2,
+    "id": "minecraft:nether_brick"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_red_nether_bricks_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_red_nether_bricks_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:red_nether_brick_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:red_nether_bricks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_red_sandstone.json
+++ b/data/crafting_plus/recipe/uncraft_red_sandstone.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:red_sandstone"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:red_sand"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_red_sandstone_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_red_sandstone_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:red_sandstone_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:red_sandstone"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_sandstone.json
+++ b/data/crafting_plus/recipe/uncraft_sandstone.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:sandstone"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:sand"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_sandstone_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_sandstone_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:sandstone_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:sandstone"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_smooth_quartz_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_smooth_quartz_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:smooth_quartz_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:smooth_quartz"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_smooth_red_sandstone_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_smooth_red_sandstone_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:smooth_red_sandstone_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:smooth_red_sandstone"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_smooth_sandstone_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_smooth_sandstone_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:smooth_sandstone_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:smooth_sandstone"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_smooth_stone_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_smooth_stone_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:smooth_stone_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:smooth_stone"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_snow_block.json
+++ b/data/crafting_plus/recipe/uncraft_snow_block.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:snow_block"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:snowball"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_spruce_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_spruce_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:spruce_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:spruce_planks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_stone_brick_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_stone_brick_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:stone_brick_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:stone_bricks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_stone_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_stone_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:stone_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:stone"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_warped_block.json
+++ b/data/crafting_plus/recipe/uncraft_warped_block.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "minecraft:warped_wart_block"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:warped_fungus"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_warped_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_warped_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:warped_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:warped_planks"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_waxed_cut_copper_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_waxed_cut_copper_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:waxed_cut_copper_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:waxed_cut_copper"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_waxed_exposed_cut_copper_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_waxed_exposed_cut_copper_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:waxed_exposed_cut_copper_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:waxed_exposed_cut_copper"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_waxed_oxidized_cut_copper_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_waxed_oxidized_cut_copper_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:waxed_oxidized_cut_copper_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:waxed_oxidized_cut_copper"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_waxed_weathered_cut_copper_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_waxed_weathered_cut_copper_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:waxed_weathered_cut_copper_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:waxed_weathered_cut_copper"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_weathered_cut_copper_slabs.json
+++ b/data/crafting_plus/recipe/uncraft_weathered_cut_copper_slabs.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "_",
+    "_"
+  ],
+  "key": {
+    "_": {
+      "item": "minecraft:weathered_cut_copper_slab"
+    }
+  },
+  "result": {
+    "count": 1,
+    "id": "minecraft:weathered_cut_copper"
+  }
+}

--- a/data/crafting_plus/recipe/uncraft_wool.json
+++ b/data/crafting_plus/recipe/uncraft_wool.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool"
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:string"
+  }
+}

--- a/data/crafting_plus/recipe/wool/black_wool.json
+++ b/data/crafting_plus/recipe/wool/black_wool.json
@@ -1,0 +1,17 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    },
+    {
+      "item": "minecraft:black_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:black_wool"
+  }
+}

--- a/data/crafting_plus/recipe/wool/blue_wool.json
+++ b/data/crafting_plus/recipe/wool/blue_wool.json
@@ -1,0 +1,17 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    },
+    {
+      "item": "minecraft:blue_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:blue_wool"
+  }
+}

--- a/data/crafting_plus/recipe/wool/brown_wool.json
+++ b/data/crafting_plus/recipe/wool/brown_wool.json
@@ -1,0 +1,17 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    },
+    {
+      "item": "minecraft:brown_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:brown_wool"
+  }
+}

--- a/data/crafting_plus/recipe/wool/cyan_wool.json
+++ b/data/crafting_plus/recipe/wool/cyan_wool.json
@@ -1,0 +1,17 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    },
+    {
+      "item": "minecraft:cyan_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:cyan_wool"
+  }
+}

--- a/data/crafting_plus/recipe/wool/gray_wool.json
+++ b/data/crafting_plus/recipe/wool/gray_wool.json
@@ -1,0 +1,17 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    },
+    {
+      "item": "minecraft:gray_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:gray_wool"
+  }
+}

--- a/data/crafting_plus/recipe/wool/green_wool.json
+++ b/data/crafting_plus/recipe/wool/green_wool.json
@@ -1,0 +1,17 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    },
+    {
+      "item": "minecraft:green_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:green_wool"
+  }
+}

--- a/data/crafting_plus/recipe/wool/light_blue_wool.json
+++ b/data/crafting_plus/recipe/wool/light_blue_wool.json
@@ -1,0 +1,17 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    },
+    {
+      "item": "minecraft:light_blue_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:light_blue_wool"
+  }
+}

--- a/data/crafting_plus/recipe/wool/light_gray_wool.json
+++ b/data/crafting_plus/recipe/wool/light_gray_wool.json
@@ -1,0 +1,17 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    },
+    {
+      "item": "minecraft:light_gray_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:light_gray_wool"
+  }
+}

--- a/data/crafting_plus/recipe/wool/lime_wool.json
+++ b/data/crafting_plus/recipe/wool/lime_wool.json
@@ -1,0 +1,17 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    },
+    {
+      "item": "minecraft:lime_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:lime_wool"
+  }
+}

--- a/data/crafting_plus/recipe/wool/magenta_wool.json
+++ b/data/crafting_plus/recipe/wool/magenta_wool.json
@@ -1,0 +1,17 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    },
+    {
+      "item": "minecraft:magenta_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:magenta_wool"
+  }
+}

--- a/data/crafting_plus/recipe/wool/orange_wool.json
+++ b/data/crafting_plus/recipe/wool/orange_wool.json
@@ -1,0 +1,17 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    },
+    {
+      "item": "minecraft:orange_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:orange_wool"
+  }
+}

--- a/data/crafting_plus/recipe/wool/pink_wool.json
+++ b/data/crafting_plus/recipe/wool/pink_wool.json
@@ -1,0 +1,17 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    },
+    {
+      "item": "minecraft:pink_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:pink_wool"
+  }
+}

--- a/data/crafting_plus/recipe/wool/purple_wool.json
+++ b/data/crafting_plus/recipe/wool/purple_wool.json
@@ -1,0 +1,17 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    },
+    {
+      "item": "minecraft:purple_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:purple_wool"
+  }
+}

--- a/data/crafting_plus/recipe/wool/red_wool.json
+++ b/data/crafting_plus/recipe/wool/red_wool.json
@@ -1,0 +1,17 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    },
+    {
+      "item": "minecraft:red_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:red_wool"
+  }
+}

--- a/data/crafting_plus/recipe/wool/white_wool.json
+++ b/data/crafting_plus/recipe/wool/white_wool.json
@@ -1,0 +1,17 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    },
+    {
+      "item": "minecraft:white_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:white_wool"
+  }
+}

--- a/data/crafting_plus/recipe/wool/yellow_wool.json
+++ b/data/crafting_plus/recipe/wool/yellow_wool.json
@@ -1,0 +1,17 @@
+{
+  "type": "crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    },
+    {
+      "item": "minecraft:yellow_dye",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:yellow_wool"
+  }
+}

--- a/data/crafting_plus/recipe/wool_to_string.json
+++ b/data/crafting_plus/recipe/wool_to_string.json
@@ -1,0 +1,13 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "tag": "minecraft:wool",
+      "count": 1
+    }
+  ],
+  "result": {
+    "count": 4,
+    "id": "minecraft:string"
+  }
+}

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-  "pack_format": 22,
+  "pack_format": 48,
   "description": "§6Quick§r and §aEnhanced§r Crafting Recipes - §eCrafting+§r By §dKxffie§r"
   }
 }


### PR DESCRIPTION
Remove "/" symbol from crafting recipes keys
Crafting recipes result.item => result.id
Smelting recipes result => result.id

**Everything should work** expect *bulk_minecart*,
which returns an error:
`Parsing error loading recipe crafting_plus:bulk_minecart
com.google.gson.JsonParseException: Item stack with stack size of 9 was larger than maximum: 1`

I don't know a way of making it work in 1.21